### PR TITLE
Change order of two statements

### DIFF
--- a/Cpp/Log.cpp
+++ b/Cpp/Log.cpp
@@ -125,10 +125,10 @@ bool CLog::Open(LPTSTR fileName, bool overwrite) {
 
 	hFile = CreateFile(fileName, GENERIC_WRITE, FILE_SHARE_READ, NULL, (overwrite ? CREATE_ALWAYS : OPEN_ALWAYS),
 		FILE_ATTRIBUTE_NORMAL, NULL);
-	lastErr = GetLastError();
 	if (hFile == INVALID_HANDLE_VALUE)
 		return false;
 
+	lastErr = GetLastError();
 	if (lastErr == ERROR_ALREADY_EXISTS && overwrite == false) {
 		retVal = SetFilePointer(hFile, 0, 0, FILE_END);
 		if (retVal > 0) 


### PR DESCRIPTION
I consider that in case the clause 'hFile == INVALID_HANDLE_VALUE' is true, then return false immediately, no need to obtain lastErr (that in case lastErr has no other use)
