### PR TITLE
fixed from PVS-Studio

### DIFF
--- a/Log.cpp
+++ b/Log.cpp
@@ -371,12 +371,12 @@ bool CVersionInfo::GetModuleVersionInfo(HMODULE hMod) {
 	modFileName = new TCHAR[MAX_PATH];
 	retVal = GetModuleFileName(hMod, modFileName, MAX_PATH);
 	if (!retVal) {
-		delete modFileName;
+		delete[] modFileName;
 		::WriteToLog(L"CLog::GetModuleVersion - Error while getting module filename...");
 		return false;
 	}
 	retVal = GetModuleVersionInfo(modFileName);
-	delete modFileName;
+	delete[] modFileName;
 	return (retVal == TRUE);
 }
 
@@ -413,7 +413,7 @@ bool CVersionInfo::GetModuleVersionInfo(LPTSTR modName = NULL) {
 	if (retVal) 
 		this->g_bVerInfoBuff = buff;
 	else 
-		if (buff) delete buff;
+		delete[] buff;
 
 	return (retVal == TRUE);
 }

--- a/stdafx.cpp
+++ b/stdafx.cpp
@@ -105,7 +105,7 @@ bool FileExists(LPTSTR fileName) {
 	h = FindFirstFile(searchPath, &wfData);
 	if (colonPtr) colonPtr[0] = ':';
 	if (h != INVALID_HANDLE_VALUE) {
-		delete searchPath;
+		delete[] searchPath;
 		FindClose(h);
 		return true;
 	}
@@ -117,7 +117,7 @@ bool FileExists(LPTSTR fileName) {
 	}
 	wcscat_s(searchPath, strMaxSize, L"*.*");
 	h = FindFirstFile(searchPath, &wfData);
-	delete searchPath;
+	delete[] searchPath;
 	if (h != INVALID_HANDLE_VALUE) {
 		FindClose(h); 
 		return true; 


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio. Warnings:

[V611](https://www.viva64.com/en/w/v611/) The memory was allocated using 'new T[]' operator but was released using the 'delete' operator. Consider inspecting this code. It's probably better to use 'delete [] modFileName;'. log.cpp 374
[V611](https://www.viva64.com/en/w/v611/) The memory was allocated using 'new T[]' operator but was released using the 'delete' operator. Consider inspecting this code. It's probably better to use 'delete [] modFileName;'. log.cpp 379
[V611](https://www.viva64.com/en/w/v611/) The memory was allocated using 'new T[]' operator but was released using the 'delete' operator. Consider inspecting this code. It's probably better to use 'delete [] buff;'. log.cpp 416
[V611](https://www.viva64.com/en/w/v611/) The memory was allocated using 'new T[]' operator but was released using the 'delete' operator. Consider inspecting this code. It's probably better to use 'delete [] searchPath;'. stdafx.cpp 108
[V611](https://www.viva64.com/en/w/v611/) The memory was allocated using 'new T[]' operator but was released using the 'delete' operator. Consider inspecting this code. It's probably better to use 'delete [] searchPath;'. stdafx.cpp 120
[V668](https://www.viva64.com/en/w/v668/) There is no sense in testing the 'buff' pointer against null, as the memory was allocated using the 'new' operator. The exception will be generated in the case of memory allocation error. log.cpp 416